### PR TITLE
修复pv uv图表部分日期不显示问题

### DIFF
--- a/source/scripts/app.js
+++ b/source/scripts/app.js
@@ -236,7 +236,7 @@ require([
       var BAIDU_CHART = 'BAIDU_CHART'
       var date = new Date()
       var start = new Date(date.getTime() - 60 * 60 * 1000 * 24 * 6)
-      var start_date = `${start.getFullYear()}${start.getMonth() + 1}${prefix(start.getDate())}`
+      var start_date = `${start.getFullYear()}${prefix(start.getMonth() + 1)}${prefix(start.getDate())}`
       var end_date = `${date.getFullYear()}${prefix(date.getMonth() + 1)}${prefix(date.getDate())}`
       var url = `https://openapi.baidu.com/rest/2.0/tongji/report/getData?access_token=${HUHU_CONFIG.baidu_tongji.access_token}&site_id=${HUHU_CONFIG.baidu_tongji.site_id}&method=overview/getTimeTrendRpt&start_date=${start_date}&end_date=${end_date}&metrics=pv_count,visitor_count`
 


### PR DESCRIPTION
在月份小于10时，起始日期会出现如 2020128 这种情况，导致api请求返回错误的结果。